### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions [skip ci]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 on:
   push:
   pull_request:
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/brendtumi/cron-ironer/security/code-scanning/2](https://github.com/brendtumi/cron-ironer/security/code-scanning/2)

To resolve the issue, you should add a `permissions` block to the workflow. As none of the shown jobs appear to need write access to repository contents (the `publish` job pushes to the npm registry, not to GitHub), the minimally sufficient permissions are `contents: read`. The recommended location for the permissions block is at the top workflow level, immediately following the `name` and `on` keys, so it applies to all jobs unless overridden later. No additional imports or definitions are necessary. This change requires inserting the following YAML block:

```yaml
permissions:
  contents: read
```

after the workflow's name/on (e.g., after line 4).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
