### PR TITLE
Potential fix for code scanning alert no. 5: Shell command built from environment values

### DIFF
--- a/scripts/generate-test-resources.js
+++ b/scripts/generate-test-resources.js
@@ -1,17 +1,17 @@
 #!/usr/bin/env node
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
 const ROOT = path.resolve(__dirname, '..');
 const INPUT_DIR = path.join(ROOT, 'test', 'resource');
 
-function run(cmd, options = {}) {
-  console.log(`$ ${cmd}`);
+function run(command, args, options = {}) {
+  console.log(`$ ${[command, ...args].map(a => JSON.stringify(a)).join(' ')}`);
   try {
-    execSync(cmd, { stdio: 'inherit', cwd: ROOT, ...options });
+    execFileSync(command, args, { stdio: 'inherit', cwd: ROOT, ...options });
   } catch (err) {
-    console.error(`Command failed: ${cmd}`);
+    console.error(`Command failed: ${[command, ...args].join(' ')}`);
     process.exitCode = 1;
   }
 }
@@ -34,13 +34,13 @@ function main() {
 
   for (const rel of files) {
     // 1) --image
-    run(`npm run -s dev -- ${rel} --image`);
+    run('npm', ['run', '-s', 'dev', '--', rel, '--image']);
     // 2) --image --suggest
-    run(`npm run -s dev -- ${rel} --image --suggest`);
+    run('npm', ['run', '-s', 'dev', '--', rel, '--image', '--suggest']);
     // 3) --image --reflect-duration
-    run(`npm run -s dev -- ${rel} --image --reflect-duration`);
+    run('npm', ['run', '-s', 'dev', '--', rel, '--image', '--reflect-duration']);
     // 4) --image --suggest --reflect-duration
-    run(`npm run -s dev -- ${rel} --image --suggest --reflect-duration`);
+    run('npm', ['run', '-s', 'dev', '--', rel, '--image', '--suggest', '--reflect-duration']);
   }
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/brendtumi/cron-ironer/security/code-scanning/5](https://github.com/brendtumi/cron-ironer/security/code-scanning/5)

To fix this issue, replace shell command construction using string interpolation with an approach that safely passes user-derived/variable data as arguments, avoiding interpretation of special shell characters. In this case, use `execFileSync` from the `child_process` module rather than `execSync`, which does not invoke a shell and allows argument separation. 

Specifically:
- Refactor the `run` function to accept a command and an array of arguments.
- Change each call to `run` (lines 37–43) so that the arguments are passed as an array rather than interpolated in a string.
- The npm invocation can be rewritten as `npm`, with `["run", "-s", "dev", "--", rel, ...additionalArgs]` where `additionalArgs` is the list of option flags.
- Handle `console.log` output so the command line is clearly printed for debugging purposes.

Required changes:
- Refactor `run` from accepting a string to taking a command and an argument array.
- Update each `run` call to pass the correct command/argument breakdown.
- Ensure all changes are limited to the edited snippet in `scripts/generate-test-resources.js`.
- No additional imports are required since `execFileSync` is part of `child_process`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
