### PR TITLE
SVG and PNG export options and Interactive HTML heatmap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,11 +21,19 @@ Cron‑Ironer, a cli tool, that helps developers spread and de‑conflict cron j
 - Run linter: `npm run lint`
 
 ### Testing Guidelines
+
 - Always work from within the package directory when running tests
 - Mock all external dependencies in unit tests
 
 ## Pull Requests
 
+- Create an entry in the [CHANGELOG's Unreleased section](./CHANGELOG.md) for any changes you make with following types of changes
+  - `Added` for new features.
+  - `Changed` for changes in existing functionality.
+  - `Deprecated` for soon-to-be removed features.
+  - `Removed` for now removed features.
+  - `Fixed` for any bug fixes.
+  - `Security` in case of vulnerabilities.
 - Always run linter and tests before submitting a PR.
 - Follow the checklist in the [PR template](.github/pull_request_template.md).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,11 @@
 
 ### Changed
 
-- Improved the interactive HTML heatmap accessibility with focusable cells and ARIA descriptions.
-- Interactive HTML heatmaps now break down starting versus continuing job runs and include a direct link to the npm package page.
 - CLI runs print the absolute paths of every generated artifact (heatmaps, HTML, suggestions) for easier discovery in automation logs.
 - The interactive HTML and ASCII heatmaps now summarize both the highest and lowest cron densities, and the HTML footer links to the npm and GitHub project pages.
 
 ### Fixed
 
-- Fixed the interactive HTML heatmap script escaping to avoid runtime syntax errors in browsers.
 - Prevented the CLI from generating before/after heatmap images during suggestion runs unless `--image` is explicitly set.
 
 ## [1.1.0] - 2025-10-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 ### Changed
 
 - Improved the interactive HTML heatmap accessibility with focusable cells and ARIA descriptions.
+- Interactive HTML heatmaps now break down starting versus continuing job runs and include a direct link to the npm package page.
+- CLI runs print the absolute paths of every generated artifact (heatmaps, HTML, suggestions) for easier discovery in automation logs.
 
 ## [1.1.0] - 2025-10-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+## Unreleased
+
+### Added
+
+- SVG and PNG export options for cron heatmaps via the `--image-format` flag.
+- Interactive HTML heatmap generation with per-minute job contribution tooltips.
+
+## [1.1.0] - 2025-10-03
+
+### Added
+
+- Greedy spread optimizer option for cron retiming
+
+## [1.0.0] - 2025-08-08
+
+### Initial release
+
+cron-ironer is a developer-friendly cli tool for visualizing and optimizing your crontab schedules.
+It helps you identify overlaps, gaps, and scheduling bottlenecks using intuitive heatmaps and
+intelligent spread suggestions — with or without duration estimates.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Improved the interactive HTML heatmap accessibility with focusable cells and ARIA descriptions.
 - Interactive HTML heatmaps now break down starting versus continuing job runs and include a direct link to the npm package page.
 - CLI runs print the absolute paths of every generated artifact (heatmaps, HTML, suggestions) for easier discovery in automation logs.
+- The interactive HTML and ASCII heatmaps now summarize both the highest and lowest cron densities, and the HTML footer links to the npm and GitHub project pages.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 - Interactive HTML heatmaps now break down starting versus continuing job runs and include a direct link to the npm package page.
 - CLI runs print the absolute paths of every generated artifact (heatmaps, HTML, suggestions) for easier discovery in automation logs.
 
+### Fixed
+
+- Fixed the interactive HTML heatmap script escaping to avoid runtime syntax errors in browsers.
+
 ## [1.1.0] - 2025-10-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - SVG and PNG export options for cron heatmaps via the `--image-format` flag.
 - Interactive HTML heatmap generation with per-minute job contribution tooltips.
 
+### Changed
+
+- Improved the interactive HTML heatmap accessibility with focusable cells and ARIA descriptions.
+
 ## [1.1.0] - 2025-10-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Fixed
 
 - Fixed the interactive HTML heatmap script escaping to avoid runtime syntax errors in browsers.
+- Prevented the CLI from generating before/after heatmap images during suggestion runs unless `--image` is explicitly set.
 
 ## [1.1.0] - 2025-10-03
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm version](https://img.shields.io/npm/v/cron-ironer)](https://www.npmjs.com/package/cron-ironer)
 ![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/brendtumi/cron-ironer/ci.yml?branch=main)
 
-Cron Ironer parses cron schedules, renders 24-hour heatmaps as ASCII or JPEG, and can suggest evenly distributed alternatives.
+Cron Ironer parses cron schedules, renders 24-hour heatmaps as ASCII, PNG, SVG, or interactive HTML, and can suggest evenly distributed alternatives.
 
 ## Installation
 
@@ -20,10 +20,12 @@ cron-ironer <file> [options]
 
 Options:
   --format <yaml|json|text>  Infer from extension by default
-  --image                    Write JPEG heatmap (min 1300x550) instead of ASCII
+  --image                    Write heatmap image (min 1300x550) instead of ASCII
+  --image-format <jpeg|png|svg>  Image format for generated heatmaps (default: jpeg)
   --suggest                  Enable schedule optimization
   --optimizer <offset|greedy>  Select optimizer when using --suggest (default: offset)
   --reflect-duration         Use job estimation (in seconds) when drawing heatmap
+  --html                     Write interactive HTML heatmap
   -o, --out-file <path>      Write heatmap to file
 ```
 
@@ -59,7 +61,7 @@ Input snippet:
 Running the command produces:
 
 - `test/resource/test-1.suggested.json` with optimized schedules
-- `test/resource/test-1.before.suggested.jpg` and `test/resource/test-1.after.suggested.jpg` heatmaps
+- `test/resource/test-1.before.suggested.jpg` and `test/resource/test-1.after.suggested.jpg` heatmaps (use `--image-format png` or `--image-format svg` for alternate formats)
 
 Output snippet (`test/resource/test-1.suggested.json`):
 
@@ -156,8 +158,10 @@ With the `greedy` optimizer, the schedule is more evenly distributed (10 Cron Jo
 ### Heatmap interpretation
 
 - Image heatmaps start at 1300 x 550 pixels and expand as needed.
+- Select the encoding with `--image-format jpeg|png|svg`.
 - The Y-axis shows hours (00-23); the X-axis lists minutes (00-59) in 5-minute increments.
 - ASCII heatmaps dedicate two characters per minute and use shading characters (`█`, `▓`, `▒`, `░`) to indicate cron job density.
+- Use `--html` to export an interactive HTML heatmap with hoverable cells listing contributing job names and raw counts.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ With the `greedy` optimizer, the schedule is more evenly distributed (10 Cron Jo
 - The Y-axis shows hours (00-23); the X-axis lists minutes (00-59) in 5-minute increments.
 - ASCII heatmaps dedicate two characters per minute and use shading characters (`█`, `▓`, `▒`, `░`) to indicate cron job density.
 - Use `--html` to export an interactive HTML heatmap with hoverable cells listing contributing job names and raw counts.
+- Keyboard users can tab through the interactive HTML heatmap; focused cells announce counts and contributing jobs via accessible tooltips.
 
 ## License
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -153,7 +153,7 @@ if (suggest) {
   }
   if (!outputImage) writeAscii(heatmap, '.before');
   if (htmlOutput) writeHtml(heatmap, '.before');
-  writeImage(matrix, '.before');
+  if (outputImage) writeImage(matrix, '.before');
 
   const suggested =
     optimizer === 'greedy'
@@ -172,7 +172,7 @@ if (suggest) {
   const matrix2 = heatmapAfter.matrix;
   if (!outputImage) writeAscii(heatmapAfter, '.after');
   if (htmlOutput) writeHtml(heatmapAfter, '.after');
-  writeImage(matrix2, '.after');
+  if (outputImage) writeImage(matrix2, '.after');
 } else {
   if (outputImage) writeImage(matrix);
   else writeAscii(heatmap);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -101,8 +101,11 @@ function replaceExt(file: string, newExt: string): string {
   return path.join(dir, `${name}${newExt}`);
 }
 
-function writeAscii(matrix: number[][], suffix = '') {
-  const content = `${renderAscii(matrix)}\n`;
+function writeAscii(heatmap: HeatmapData, suffix = '') {
+  const content = `${renderAscii(heatmap.matrix, false, {
+    maxValue: heatmap.maxValue,
+    minValue: heatmap.minValue,
+  })}\n`;
   let finalSuffix = suffix;
   if (suggest) finalSuffix = `${finalSuffix}.suggested`;
   if (reflect) finalSuffix = `${finalSuffix}.reflect`;
@@ -148,7 +151,7 @@ if (suggest) {
   if (optimizer !== 'offset' && optimizer !== 'greedy') {
     program.error(`Unknown optimizer: ${optimizer}`);
   }
-  if (!outputImage) writeAscii(matrix, '.before');
+  if (!outputImage) writeAscii(heatmap, '.before');
   if (htmlOutput) writeHtml(heatmap, '.before');
   writeImage(matrix, '.before');
 
@@ -167,12 +170,12 @@ if (suggest) {
 
   const heatmapAfter = buildHeatmapData(suggested, reflect);
   const matrix2 = heatmapAfter.matrix;
-  if (!outputImage) writeAscii(matrix2, '.after');
+  if (!outputImage) writeAscii(heatmapAfter, '.after');
   if (htmlOutput) writeHtml(heatmapAfter, '.after');
   writeImage(matrix2, '.after');
 } else {
   if (outputImage) writeImage(matrix);
-  else writeAscii(matrix);
+  else writeAscii(heatmap);
   if (htmlOutput) writeHtml(heatmap);
 }
 

--- a/src/heatmap/buildMatrix.ts
+++ b/src/heatmap/buildMatrix.ts
@@ -1,5 +1,11 @@
 import parser from 'cron-parser';
-import { ContributionMatrix, HeatmapData, Job, Matrix } from '../types';
+import {
+  ContributionMatrix,
+  HeatmapContribution,
+  HeatmapData,
+  Job,
+  Matrix,
+} from '../types';
 
 function createMatrix(): Matrix {
   return Array.from({ length: 24 }, () => Array(60).fill(0));
@@ -7,7 +13,7 @@ function createMatrix(): Matrix {
 
 function createContributionMatrix(): ContributionMatrix {
   return Array.from({ length: 24 }, () =>
-    Array.from({ length: 60 }, () => [] as string[]),
+    Array.from({ length: 60 }, () => [] as HeatmapContribution[]),
   );
 }
 
@@ -54,7 +60,10 @@ function buildRawMatrix(jobs: Job[], options: BuildOptions): BuildResult {
           if (hh < 24) {
             matrix[hh][mm] += 1;
             if (contributions) {
-              contributions[hh][mm].push(job.name);
+              contributions[hh][mm].push({
+                name: job.name,
+                status: k === 0 ? 'starting' : 'continuing',
+              });
             }
           }
         }

--- a/src/heatmap/buildMatrix.ts
+++ b/src/heatmap/buildMatrix.ts
@@ -26,6 +26,7 @@ interface BuildResult {
   raw: Matrix;
   contributions?: ContributionMatrix;
   maxValue: number;
+  minValue: number;
 }
 
 function buildRawMatrix(jobs: Job[], options: BuildOptions): BuildResult {
@@ -77,13 +78,21 @@ function buildRawMatrix(jobs: Job[], options: BuildOptions): BuildResult {
   });
 
   let max = 0;
+  let min = Infinity;
   for (let h = 0; h < matrix.length; h += 1) {
     for (let m = 0; m < matrix[h].length; m += 1) {
-      if (matrix[h][m] > max) max = matrix[h][m];
+      const value = matrix[h][m];
+      if (value > max) max = value;
+      if (value > 0 && value < min) min = value;
     }
   }
 
-  return { raw: matrix, contributions, maxValue: max };
+  return {
+    raw: matrix,
+    contributions,
+    maxValue: max,
+    minValue: Number.isFinite(min) ? min : 0,
+  };
 }
 
 function normalizeMatrix(raw: Matrix, maxValue: number): Matrix {
@@ -101,7 +110,7 @@ export function buildHeatmapData(
   jobs: Job[],
   reflectDuration = false,
 ): HeatmapData {
-  const { raw, contributions, maxValue } = buildRawMatrix(jobs, {
+  const { raw, contributions, maxValue, minValue } = buildRawMatrix(jobs, {
     reflectDuration,
     collectContributions: true,
   });
@@ -112,6 +121,7 @@ export function buildHeatmapData(
     raw,
     contributions,
     maxValue,
+    minValue,
     matrix: normalizeMatrix(raw, maxValue),
   };
 }

--- a/src/heatmap/buildMatrix.ts
+++ b/src/heatmap/buildMatrix.ts
@@ -1,15 +1,32 @@
 import parser from 'cron-parser';
-import { Job, Matrix } from '../types';
+import { ContributionMatrix, HeatmapData, Job, Matrix } from '../types';
 
 function createMatrix(): Matrix {
   return Array.from({ length: 24 }, () => Array(60).fill(0));
 }
 
-export default function buildMatrix(
-  jobs: Job[],
-  reflectDuration = false,
-): Matrix {
+function createContributionMatrix(): ContributionMatrix {
+  return Array.from({ length: 24 }, () =>
+    Array.from({ length: 60 }, () => [] as string[]),
+  );
+}
+
+interface BuildOptions {
+  reflectDuration: boolean;
+  collectContributions: boolean;
+}
+
+interface BuildResult {
+  raw: Matrix;
+  contributions?: ContributionMatrix;
+  maxValue: number;
+}
+
+function buildRawMatrix(jobs: Job[], options: BuildOptions): BuildResult {
   const matrix = createMatrix();
+  const contributions = options.collectContributions
+    ? createContributionMatrix()
+    : undefined;
   const start = new Date();
   start.setHours(0, 0, 0, 0);
   const end = new Date(start);
@@ -27,14 +44,19 @@ export default function buildMatrix(
         const h = d.getHours();
         const m = d.getMinutes();
         const durationMinutes =
-          reflectDuration && job.estimation
+          options.reflectDuration && job.estimation
             ? Math.ceil(job.estimation / 60)
             : 1;
         for (let k = 0; k < durationMinutes; k += 1) {
           const idx = h * 60 + m + k;
           const hh = Math.floor(idx / 60);
           const mm = idx % 60;
-          if (hh < 24) matrix[hh][mm] += 1;
+          if (hh < 24) {
+            matrix[hh][mm] += 1;
+            if (contributions) {
+              contributions[hh][mm].push(job.name);
+            }
+          }
         }
       }
     } catch (err) {
@@ -45,14 +67,53 @@ export default function buildMatrix(
     }
   });
 
-  const max = Math.max(...matrix.flat());
-  if (max > 0) {
-    for (let h = 0; h < matrix.length; h += 1) {
-      for (let m = 0; m < matrix[h].length; m += 1) {
-        matrix[h][m] = Math.ceil((matrix[h][m] * 9) / max);
-      }
+  let max = 0;
+  for (let h = 0; h < matrix.length; h += 1) {
+    for (let m = 0; m < matrix[h].length; m += 1) {
+      if (matrix[h][m] > max) max = matrix[h][m];
     }
   }
 
-  return matrix;
+  return { raw: matrix, contributions, maxValue: max };
+}
+
+function normalizeMatrix(raw: Matrix, maxValue: number): Matrix {
+  const normalized = createMatrix();
+  if (maxValue === 0) return normalized;
+  for (let h = 0; h < raw.length; h += 1) {
+    for (let m = 0; m < raw[h].length; m += 1) {
+      normalized[h][m] = Math.ceil((raw[h][m] * 9) / maxValue);
+    }
+  }
+  return normalized;
+}
+
+export function buildHeatmapData(
+  jobs: Job[],
+  reflectDuration = false,
+): HeatmapData {
+  const { raw, contributions, maxValue } = buildRawMatrix(jobs, {
+    reflectDuration,
+    collectContributions: true,
+  });
+  if (!contributions) {
+    throw new Error('Contributions matrix missing from heatmap data build');
+  }
+  return {
+    raw,
+    contributions,
+    maxValue,
+    matrix: normalizeMatrix(raw, maxValue),
+  };
+}
+
+export default function buildMatrix(
+  jobs: Job[],
+  reflectDuration = false,
+): Matrix {
+  const { raw, maxValue } = buildRawMatrix(jobs, {
+    reflectDuration,
+    collectContributions: false,
+  });
+  return normalizeMatrix(raw, maxValue);
 }

--- a/src/heatmap/palette.ts
+++ b/src/heatmap/palette.ts
@@ -1,0 +1,26 @@
+export type RgbTuple = [number, number, number];
+
+export const palette: readonly RgbTuple[] = [
+  [247, 251, 255],
+  [222, 235, 247],
+  [198, 219, 239],
+  [158, 202, 225],
+  [107, 174, 214],
+  [66, 146, 198],
+  [33, 113, 181],
+  [8, 81, 156],
+  [8, 48, 107],
+  [3, 19, 43],
+] as const;
+
+export function getColor(value: number): RgbTuple {
+  const safeValue = Number.isFinite(value) ? Math.max(value, 0) : 0;
+  const index = Math.min(safeValue, palette.length - 1);
+  return palette[index] as RgbTuple;
+}
+
+export function colorToHex(color: RgbTuple): string {
+  return `#${color
+    .map((component) => component.toString(16).padStart(2, '0'))
+    .join('')}`;
+}

--- a/src/heatmap/renderInteractiveHtml.ts
+++ b/src/heatmap/renderInteractiveHtml.ts
@@ -1,4 +1,4 @@
-import { HeatmapData } from '../types';
+import { HeatmapContribution, HeatmapData } from '../types';
 import { colorToHex, getColor, palette } from './palette';
 
 function buildLegend(): string {
@@ -13,12 +13,59 @@ function buildLegend(): string {
   return `<div class="legend" aria-label="Heatmap intensity legend" role="group">${steps}</div>`;
 }
 
-function encodeJobs(jobs: string[]): string {
-  return encodeURIComponent(JSON.stringify(jobs));
+function encodeContributions(entries: HeatmapContribution[]): string {
+  return encodeURIComponent(JSON.stringify(entries));
 }
 
 function sanitizeNumber(value: number): string {
   return Number.isFinite(value) ? String(value) : '0';
+}
+
+interface ContributionBucketEntry {
+  name: string;
+  count: number;
+}
+
+interface ContributionSummary {
+  startingCount: number;
+  continuingCount: number;
+  starting: ContributionBucketEntry[];
+  continuing: ContributionBucketEntry[];
+}
+
+function summarizeContributions(
+  entries: HeatmapContribution[],
+): ContributionSummary {
+  const startingMap = new Map<string, number>();
+  const continuingMap = new Map<string, number>();
+  let startingCount = 0;
+  let continuingCount = 0;
+
+  entries.forEach((entry) => {
+    if (!entry || typeof entry.name !== 'string') {
+      return;
+    }
+    const key = entry.name;
+    if (entry.status === 'continuing') {
+      continuingCount += 1;
+      continuingMap.set(key, (continuingMap.get(key) || 0) + 1);
+    } else {
+      startingCount += 1;
+      startingMap.set(key, (startingMap.get(key) || 0) + 1);
+    }
+  });
+
+  const sortBucket = (bucket: Map<string, number>): ContributionBucketEntry[] =>
+    Array.from(bucket.entries())
+      .map(([name, count]) => ({ name, count }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+
+  return {
+    startingCount,
+    continuingCount,
+    starting: sortBucket(startingMap),
+    continuing: sortBucket(continuingMap),
+  };
 }
 
 function escapeAttribute(value: string): string {
@@ -30,18 +77,39 @@ function escapeAttribute(value: string): string {
     .replace(/>/g, '&gt;');
 }
 
+function formatBucketForAria(entries: ContributionBucketEntry[]): string {
+  if (!entries.length) {
+    return 'none';
+  }
+  return entries
+    .map((entry) =>
+      entry.count > 1 ? `${entry.name} (${entry.count})` : entry.name,
+    )
+    .join(', ');
+}
+
 function buildAriaLabel(
   hour: string,
   minute: string,
   count: number,
-  jobs: string[],
+  summary: ContributionSummary,
 ): string {
   const runsLabel = count === 1 ? 'run' : 'runs';
-  const base = `${hour}:${minute} has ${count} ${runsLabel}.`;
-  if (jobs.length === 0) {
-    return `${base} No jobs scheduled.`;
+  const parts = [`${hour}:${minute} has ${count} ${runsLabel}.`];
+  if (summary.startingCount > 0) {
+    const bucketLabel =
+      summary.startingCount === 1 ? 'Starting run' : 'Starting runs';
+    parts.push(`${bucketLabel}: ${formatBucketForAria(summary.starting)}.`);
   }
-  return `${base} Jobs: ${jobs.join(', ')}.`;
+  if (summary.continuingCount > 0) {
+    const bucketLabel =
+      summary.continuingCount === 1 ? 'Continuing run' : 'Continuing runs';
+    parts.push(`${bucketLabel}: ${formatBucketForAria(summary.continuing)}.`);
+  }
+  if (summary.startingCount === 0 && summary.continuingCount === 0) {
+    parts.push('No jobs scheduled.');
+  }
+  return parts.join(' ');
 }
 
 export default function renderInteractiveHtml(data: HeatmapData): string {
@@ -70,17 +138,26 @@ export default function renderInteractiveHtml(data: HeatmapData): string {
       const value = matrix[h][m];
       const color = colorToHex(getColor(value));
       const rawValue = raw[h][m];
-      const jobNames = Array.from(new Set(contributions[h][m] || [])).sort();
-      const encodedJobs = encodeJobs(jobNames);
+      const entryList = contributions[h][m] || [];
+      const summary = summarizeContributions(entryList);
+      const encodedContributions = encodeContributions(entryList);
       const hourLabel = String(h).padStart(2, '0');
       const minuteLabel = String(m).padStart(2, '0');
       const x = leftMargin + m * pitch;
       const y = topMargin + h * pitch;
       const ariaLabel = escapeAttribute(
-        buildAriaLabel(hourLabel, minuteLabel, rawValue, jobNames),
+        buildAriaLabel(hourLabel, minuteLabel, rawValue, summary),
       );
       cells.push(
-        `<rect class="cell" tabindex="0" x="${x}" y="${y}" width="${cellSize}" height="${cellSize}" fill="${color}" data-hour="${hourLabel}" data-minute="${minuteLabel}" data-count="${sanitizeNumber(rawValue)}" data-jobs="${encodedJobs}" aria-label="${ariaLabel}" />`,
+        `<rect class="cell" tabindex="0" x="${x}" y="${y}" width="${cellSize}" height="${cellSize}" fill="${color}" data-hour="${hourLabel}" data-minute="${minuteLabel}" data-count="${sanitizeNumber(
+          rawValue,
+        )}" data-contributions="${escapeAttribute(
+          encodedContributions,
+        )}" data-starting="${sanitizeNumber(
+          summary.startingCount,
+        )}" data-continuing="${sanitizeNumber(
+          summary.continuingCount,
+        )}" aria-label="${ariaLabel}" />`,
       );
     }
   }
@@ -140,33 +217,106 @@ export default function renderInteractiveHtml(data: HeatmapData): string {
     });
   }
 
-  function renderJobs(jobs) {
-    if (!Array.isArray(jobs) || jobs.length === 0) {
-      return '<p>No jobs scheduled.</p>';
-    }
-    return (
-      '<ul>' +
-      jobs.map((job) => '<li>' + escapeHtml(job) + '</li>').join('') +
-      '</ul>'
-    );
-  }
-
-  function readJobs(cell) {
-    const jobsAttr = cell.getAttribute('data-jobs') || encodeURIComponent('[]');
+  function parseContributions(cell) {
+    const raw = cell.getAttribute('data-contributions') || encodeURIComponent('[]');
     try {
-      const parsed = JSON.parse(decodeURIComponent(jobsAttr));
-      return Array.isArray(parsed) ? parsed : [];
+      const parsed = JSON.parse(decodeURIComponent(raw));
+      if (!Array.isArray(parsed)) return [];
+      return parsed
+        .map((entry) => ({
+          name: typeof entry.name === 'string' ? entry.name : '',
+          status: entry.status === 'continuing' ? 'continuing' : 'starting',
+        }))
+        .filter((entry) => entry.name);
     } catch (err) {
       return [];
     }
+  }
+
+  function bucketize(entries) {
+    const starting = new Map();
+    const continuing = new Map();
+    entries.forEach((entry) => {
+      const bucket = entry.status === 'continuing' ? continuing : starting;
+      const current = bucket.get(entry.name) || 0;
+      bucket.set(entry.name, current + 1);
+    });
+    return { starting, continuing };
+  }
+
+  function countBucket(bucket) {
+    let total = 0;
+    bucket.forEach((value) => {
+      total += value;
+    });
+    return total;
+  }
+
+  function renderBucket(label, bucket) {
+    const entries = Array.from(bucket.entries()).sort((a, b) =>
+      a[0].localeCompare(b[0]),
+    );
+    if (entries.length === 0) {
+      return '';
+    }
+    const total = countBucket(bucket);
+    return (
+      '<div class="bucket">' +
+      '<p><strong>' +
+      escapeHtml(label) +
+      ' (' +
+      total +
+      ')</strong></p>' +
+      '<ul>' +
+      entries
+        .map(([name, count]) =>
+          '<li>' +
+          escapeHtml(name) +
+          (count > 1
+            ? ' <span class="count">×' + count + '</span>'
+            : '') +
+          '</li>',
+        )
+        .join('') +
+      '</ul>' +
+      '</div>'
+    );
+  }
+
+  function renderContributionDetails(entries) {
+    if (!Array.isArray(entries) || entries.length === 0) {
+      return '<p>No jobs scheduled.</p>';
+    }
+    const buckets = bucketize(entries);
+    const content =
+      renderBucket('Starting', buckets.starting) +
+      renderBucket('Continuing', buckets.continuing);
+    if (content) {
+      return '<div class="bucket-list">' + content + '</div>';
+    }
+    return '<p>No jobs scheduled.</p>';
+  }
+
+  function formatSummary(starting, continuing) {
+    const parts = [];
+    if (starting > 0) {
+      parts.push('Starting: ' + starting);
+    }
+    if (continuing > 0) {
+      parts.push('Continuing: ' + continuing);
+    }
+    return parts.join(' • ');
   }
 
   function showTooltip(cell, event) {
     const hour = cell.getAttribute('data-hour') || '00';
     const minute = cell.getAttribute('data-minute') || '00';
     const count = Number(cell.getAttribute('data-count') || '0');
-    const jobs = readJobs(cell);
+    const starting = Number(cell.getAttribute('data-starting') || '0');
+    const continuing = Number(cell.getAttribute('data-continuing') || '0');
+    const contributions = parseContributions(cell);
     const runsLabel = count === 1 ? 'run' : 'runs';
+    const summary = formatSummary(starting, continuing);
     tooltip.innerHTML =
       '<strong>' +
       escapeHtml(hour + ':' + minute) +
@@ -174,7 +324,10 @@ export default function renderInteractiveHtml(data: HeatmapData): string {
       '<span>' +
       escapeHtml(count + ' ' + runsLabel) +
       '</span>' +
-      renderJobs(jobs);
+      (summary
+        ? '<span class="summary">' + escapeHtml(summary) + '</span>'
+        : '') +
+      renderContributionDetails(contributions);
     tooltip.style.opacity = '1';
     if (event && typeof event.clientX === 'number' && typeof event.clientY === 'number') {
       updatePosition(event);
@@ -259,6 +412,17 @@ export default function renderInteractiveHtml(data: HeatmapData): string {
       rect.cell:focus {
         outline: none;
       }
+      p.meta {
+        margin: 8px 0 0;
+      }
+      p.meta a {
+        color: #175cd3;
+        text-decoration: none;
+      }
+      p.meta a:hover,
+      p.meta a:focus {
+        text-decoration: underline;
+      }
       .legend {
         display: flex;
         flex-wrap: wrap;
@@ -301,12 +465,37 @@ export default function renderInteractiveHtml(data: HeatmapData): string {
       #tooltip p {
         margin: 8px 0 0;
       }
+      #tooltip .summary {
+        display: block;
+        margin-top: 4px;
+        font-size: 0.75rem;
+        color: #cbd2d9;
+      }
+      .bucket-list {
+        margin-top: 12px;
+      }
+      .bucket {
+        margin-top: 8px;
+      }
+      .bucket p {
+        margin: 0;
+      }
+      .bucket ul {
+        margin: 4px 0 0;
+        padding-left: 20px;
+      }
+      .bucket .count {
+        color: #cbd2d9;
+        font-size: 0.75rem;
+        margin-left: 4px;
+      }
     </style>
   </head>
   <body>
     <div class="page">
       <h1>Cron Ironer Heatmap</h1>
-      <p class="description">Hover over a minute to inspect job contributions. Highest density: ${maxValue} runs.</p>
+      <p class="description">Hover over a minute to inspect starting and continuing job contributions. Highest density: ${maxValue} runs.</p>
+      <p class="meta"><a href="https://www.npmjs.com/package/cron-ironer" target="_blank" rel="noreferrer noopener">View cron-ironer on npm</a></p>
       <svg viewBox="0 0 ${width} ${height}" role="img" aria-labelledby="heatmap-title heatmap-desc">
         <title id="heatmap-title">Cron activity heatmap</title>
         <desc id="heatmap-desc">Each cell shows the number of cron jobs scheduled for a given hour and minute.</desc>

--- a/src/heatmap/renderInteractiveHtml.ts
+++ b/src/heatmap/renderInteractiveHtml.ts
@@ -1,0 +1,269 @@
+import { HeatmapData } from '../types';
+import { colorToHex, getColor, palette } from './palette';
+
+function buildLegend(): string {
+  const steps = palette
+    .map((color, idx) => {
+      const label = idx === palette.length - 1 ? `${idx}+` : `${idx}`;
+      return `<div class="legend-item"><span class="legend-step" style="background:${colorToHex(
+        color,
+      )}" aria-hidden="true"></span><span class="legend-label">${label}</span></div>`;
+    })
+    .join('');
+  return `<div class="legend" aria-label="Heatmap intensity legend" role="group">${steps}</div>`;
+}
+
+function encodeJobs(jobs: string[]): string {
+  return encodeURIComponent(JSON.stringify(jobs));
+}
+
+function sanitizeNumber(value: number): string {
+  return Number.isFinite(value) ? String(value) : '0';
+}
+
+export default function renderInteractiveHtml(data: HeatmapData): string {
+  const { matrix, raw, contributions, maxValue } = data;
+  const rows = matrix.length;
+  const cols = matrix[0]?.length || 0;
+  const fontSize = 12;
+  const labelGap = 4;
+  const cellSize = 20;
+  const gap = 1;
+  const pitch = cellSize + gap;
+
+  const labelWidthMeasure = 18; // fallback width if measurement is unavailable
+  const labelWidth = labelWidthMeasure;
+  const leftMargin = Math.floor(labelWidth + labelGap * 2);
+  const rightMargin = leftMargin;
+  const topMargin = Math.floor(fontSize + labelGap * 2);
+  const bottomMargin = topMargin;
+
+  const width = Math.max(leftMargin + cols * pitch - gap + rightMargin, 1);
+  const height = Math.max(topMargin + rows * pitch - gap + bottomMargin, 1);
+
+  const cells: string[] = [];
+  for (let h = 0; h < rows; h += 1) {
+    for (let m = 0; m < cols; m += 1) {
+      const value = matrix[h][m];
+      const color = colorToHex(getColor(value));
+      const rawValue = raw[h][m];
+      const jobNames = Array.from(new Set(contributions[h][m] || [])).sort();
+      const encodedJobs = encodeJobs(jobNames);
+      const hourLabel = String(h).padStart(2, '0');
+      const minuteLabel = String(m).padStart(2, '0');
+      const x = leftMargin + m * pitch;
+      const y = topMargin + h * pitch;
+      cells.push(
+        `<rect class="cell" x="${x}" y="${y}" width="${cellSize}" height="${cellSize}" fill="${color}" data-hour="${hourLabel}" data-minute="${minuteLabel}" data-count="${sanitizeNumber(rawValue)}" data-jobs="${encodedJobs}" />`,
+      );
+    }
+  }
+
+  const labels: string[] = [];
+  for (let m = 0; m < cols; m += 5) {
+    const minute = String(m).padStart(2, '0');
+    const x = leftMargin + m * pitch + cellSize / 2;
+    labels.push(
+      `<text x="${x}" y="${topMargin - labelGap}" text-anchor="middle" alignment-baseline="baseline">${minute}</text>`,
+    );
+    labels.push(
+      `<text x="${x}" y="${topMargin + rows * pitch - gap + labelGap}" text-anchor="middle" alignment-baseline="hanging">${minute}</text>`,
+    );
+  }
+
+  for (let h = 0; h < rows; h += 1) {
+    const hour = String(h).padStart(2, '0');
+    const y = topMargin + h * pitch + cellSize / 2;
+    labels.push(
+      `<text x="${leftMargin - labelGap}" y="${y}" text-anchor="end" alignment-baseline="middle">${hour}</text>`,
+    );
+    labels.push(
+      `<text x="${leftMargin + cols * pitch - gap + labelGap}" y="${y}" text-anchor="start" alignment-baseline="middle">${hour}</text>`,
+    );
+  }
+
+  const legend = buildLegend();
+
+  const script = `(() => {
+  const tooltip = document.getElementById('tooltip');
+  if (!tooltip) return;
+
+  const OFFSET = 16;
+
+  function updatePosition(event) {
+    tooltip.style.left = String(event.clientX + OFFSET) + 'px';
+    tooltip.style.top = String(event.clientY + OFFSET) + 'px';
+  }
+
+  function escapeHtml(value) {
+    return String(value).replace(/[&<>"']/g, (char) => {
+      switch (char) {
+        case '&':
+          return '&amp;';
+        case '<':
+          return '&lt;';
+        case '>':
+          return '&gt;';
+        case '"':
+          return '&quot;';
+        case '\'':
+          return '&#39;';
+        default:
+          return char;
+      }
+    });
+  }
+
+  function renderJobs(jobs) {
+    if (!Array.isArray(jobs) || jobs.length === 0) {
+      return '<p>No jobs scheduled.</p>';
+    }
+    return (
+      '<ul>' +
+      jobs.map((job) => '<li>' + escapeHtml(job) + '</li>').join('') +
+      '</ul>'
+    );
+  }
+
+  document.querySelectorAll('rect.cell').forEach((cell) => {
+    cell.addEventListener('pointerenter', (event) => {
+      const hour = cell.getAttribute('data-hour') || '00';
+      const minute = cell.getAttribute('data-minute') || '00';
+      const count = Number(cell.getAttribute('data-count') || '0');
+      const jobsAttr = cell.getAttribute('data-jobs') || encodeURIComponent('[]');
+      let jobs = [];
+      try {
+        jobs = JSON.parse(decodeURIComponent(jobsAttr));
+      } catch (err) {
+        jobs = [];
+      }
+      const runsLabel = count === 1 ? 'run' : 'runs';
+      tooltip.innerHTML =
+        '<strong>' +
+        escapeHtml(hour + ':' + minute) +
+        '</strong><br />' +
+        '<span>' +
+        escapeHtml(count + ' ' + runsLabel) +
+        '</span>' +
+        renderJobs(jobs);
+      tooltip.style.opacity = '1';
+      updatePosition(event);
+    });
+
+    cell.addEventListener('pointermove', updatePosition);
+
+    cell.addEventListener('pointerleave', () => {
+      tooltip.style.opacity = '0';
+    });
+  });
+})();`;
+
+  return `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Cron Ironer Heatmap</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      :root {
+        color-scheme: light dark;
+      }
+      body {
+        margin: 0;
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        background: #f5f7fa;
+        color: #1f2933;
+      }
+      .page {
+        max-width: 960px;
+        margin: 0 auto;
+        padding: 24px 16px 48px;
+      }
+      h1 {
+        font-size: 1.5rem;
+        margin-bottom: 0.25rem;
+      }
+      p.description {
+        margin-top: 0;
+        color: #52606d;
+      }
+      svg {
+        width: 100%;
+        height: auto;
+        display: block;
+        background: #eee;
+        border-radius: 8px;
+        box-shadow: 0 1px 2px rgba(15, 23, 42, 0.12);
+      }
+      text {
+        font-family: 'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+        font-size: 12px;
+        fill: #1f2933;
+      }
+      rect.cell {
+        cursor: pointer;
+      }
+      rect.cell:hover {
+        stroke: #111827;
+        stroke-width: 0.75;
+      }
+      .legend {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+        align-items: center;
+        margin-top: 16px;
+        font-size: 0.75rem;
+        color: #616e7c;
+      }
+      .legend-item {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+      }
+      .legend-step {
+        width: 36px;
+        height: 10px;
+        border-radius: 4px;
+        border: 1px solid rgba(15, 23, 42, 0.08);
+      }
+      #tooltip {
+        position: fixed;
+        pointer-events: none;
+        background: rgba(15, 23, 42, 0.94);
+        color: #f9fafb;
+        padding: 8px 12px;
+        border-radius: 6px;
+        font-size: 0.8rem;
+        line-height: 1.4;
+        box-shadow: 0 4px 20px rgba(15, 23, 42, 0.2);
+        opacity: 0;
+        transition: opacity 120ms ease;
+        max-width: 280px;
+        z-index: 10;
+      }
+      #tooltip ul {
+        padding-left: 20px;
+        margin: 8px 0 0;
+      }
+      #tooltip p {
+        margin: 8px 0 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="page">
+      <h1>Cron Ironer Heatmap</h1>
+      <p class="description">Hover over a minute to inspect job contributions. Highest density: ${maxValue} runs.</p>
+      <svg viewBox="0 0 ${width} ${height}" role="img" aria-labelledby="heatmap-title heatmap-desc">
+        <title id="heatmap-title">Cron activity heatmap</title>
+        <desc id="heatmap-desc">Each cell shows the number of cron jobs scheduled for a given hour and minute.</desc>
+        ${[...cells, ...labels].join('\n        ')}
+      </svg>
+      ${legend}
+    </div>
+    <div id="tooltip" role="status" aria-live="polite"></div>
+    <script>${script}</script>
+  </body>
+</html>`;
+}

--- a/src/heatmap/renderInteractiveHtml.ts
+++ b/src/heatmap/renderInteractiveHtml.ts
@@ -113,7 +113,7 @@ function buildAriaLabel(
 }
 
 export default function renderInteractiveHtml(data: HeatmapData): string {
-  const { matrix, raw, contributions, maxValue } = data;
+  const { matrix, raw, contributions, maxValue, minValue } = data;
   const rows = matrix.length;
   const cols = matrix[0]?.length || 0;
   const fontSize = 12;
@@ -186,6 +186,9 @@ export default function renderInteractiveHtml(data: HeatmapData): string {
   }
 
   const legend = buildLegend();
+  const highestSummary = `${maxValue} ${maxValue === 1 ? 'run' : 'runs'}`;
+  const lowestSummary =
+    minValue > 0 ? `${minValue} ${minValue === 1 ? 'run' : 'runs'}` : 'no runs';
 
   const script = `(() => {
   const tooltip = document.getElementById('tooltip');
@@ -413,15 +416,35 @@ export default function renderInteractiveHtml(data: HeatmapData): string {
         outline: none;
       }
       p.meta {
-        margin: 8px 0 0;
+        margin: 24px 0 0;
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 8px;
+        color: #52606d;
+        font-size: 0.95rem;
       }
       p.meta a {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
         color: #175cd3;
         text-decoration: none;
+        font-weight: 600;
       }
       p.meta a:hover,
       p.meta a:focus {
         text-decoration: underline;
+      }
+      p.meta .icon {
+        width: 18px;
+        height: 18px;
+        display: inline-flex;
+      }
+      p.meta .icon svg {
+        width: 100%;
+        height: 100%;
+        display: block;
       }
       .legend {
         display: flex;
@@ -494,14 +517,14 @@ export default function renderInteractiveHtml(data: HeatmapData): string {
   <body>
     <div class="page">
       <h1>Cron Ironer Heatmap</h1>
-      <p class="description">Hover over a minute to inspect starting and continuing job contributions. Highest density: ${maxValue} runs.</p>
-      <p class="meta"><a href="https://www.npmjs.com/package/cron-ironer" target="_blank" rel="noreferrer noopener">View cron-ironer on npm</a></p>
+      <p class="description">Hover over a minute to inspect starting and continuing job contributions. Highest density: ${highestSummary}. Lowest density: ${lowestSummary}.</p>
       <svg viewBox="0 0 ${width} ${height}" role="img" aria-labelledby="heatmap-title heatmap-desc">
         <title id="heatmap-title">Cron activity heatmap</title>
         <desc id="heatmap-desc">Each cell shows the number of cron jobs scheduled for a given hour and minute.</desc>
         ${[...cells, ...labels].join('\n        ')}
       </svg>
       ${legend}
+      <p class="meta">View cron-ironer on <a class="meta-link" href="https://www.npmjs.com/package/cron-ironer" target="_blank" rel="noreferrer noopener"><span class="icon" aria-hidden="true"><svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" role="img" focusable="false"><rect width="32" height="32" rx="4" fill="#CC3534" /><path fill="#fff" d="M6 10h20v12h-6v-8h-4v8H6z" /></svg></span>Npm</a> or <a class="meta-link" href="https://github.com/brendtumi/cron-ironer" target="_blank" rel="noreferrer noopener"><span class="icon" aria-hidden="true"><svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" focusable="false"><path fill="#171515" d="M12 .5C5.65.5.5 5.65.5 12.02c0 5.1 3.29 9.43 7.86 10.96.57.1.78-.25.78-.55 0-.27-.01-1.18-.02-2.14-3.2.7-3.88-1.54-3.88-1.54-.52-1.32-1.27-1.68-1.27-1.68-1.04-.71.08-.7.08-.7 1.15.08 1.75 1.18 1.75 1.18 1.02 1.74 2.68 1.24 3.34.95.1-.74.4-1.24.73-1.53-2.55-.29-5.23-1.27-5.23-5.66 0-1.25.45-2.27 1.17-3.07-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.15 1.17.91-.25 1.88-.38 2.85-.39.97.01 1.94.14 2.85.39 2.19-1.48 3.15-1.17 3.15-1.17.62 1.58.23 2.75.11 3.04.73.8 1.17 1.82 1.17 3.07 0 4.4-2.69 5.36-5.25 5.65.41.35.78 1.04.78 2.1 0 1.52-.01 2.74-.01 3.11 0 .3.21.65.79.54A10.53 10.53 0 0 0 23.5 12C23.5 5.65 18.35.5 12 .5Z" /></svg></span>Github</a>.</p>
     </div>
     <div id="tooltip" role="status" aria-live="polite"></div>
     <script>${script}</script>

--- a/src/heatmap/renderInteractiveHtml.ts
+++ b/src/heatmap/renderInteractiveHtml.ts
@@ -209,7 +209,7 @@ export default function renderInteractiveHtml(data: HeatmapData): string {
           return '&gt;';
         case '"':
           return '&quot;';
-        case '\'':
+        case "'":
           return '&#39;';
         default:
           return char;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,9 +2,14 @@ export { default as parseYaml } from './parsers/parseYaml';
 export { default as parseJson } from './parsers/parseJson';
 export { default as parseCrontab } from './parsers/parseCrontab';
 export { default as serializeCrontab } from './parsers/serializeCrontab';
-export { default as buildMatrix } from './heatmap/buildMatrix';
+export {
+  default as buildMatrix,
+  buildHeatmapData,
+} from './heatmap/buildMatrix';
 export { default as renderAscii } from './heatmap/renderAscii';
 export { default as renderImage } from './heatmap/renderImage';
+export type { ImageFormat, RenderImageOptions } from './heatmap/renderImage';
+export { default as renderInteractiveHtml } from './heatmap/renderInteractiveHtml';
 export { default as suggestSpread } from './optimizer/suggestSpread';
 export { default as suggestAggressiveSpread } from './optimizer/suggestAggressiveSpread';
 export * from './types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,12 @@ export interface Job {
 
 export type Matrix = number[][]; // 24 x 60
 
-export type ContributionMatrix = string[][][];
+export interface HeatmapContribution {
+  name: string;
+  status: 'starting' | 'continuing';
+}
+
+export type ContributionMatrix = HeatmapContribution[][][];
 
 export interface HeatmapData {
   matrix: Matrix;

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,4 +20,5 @@ export interface HeatmapData {
   raw: Matrix;
   contributions: ContributionMatrix;
   maxValue: number;
+  minValue: number;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,3 +7,12 @@ export interface Job {
 }
 
 export type Matrix = number[][]; // 24 x 60
+
+export type ContributionMatrix = string[][][];
+
+export interface HeatmapData {
+  matrix: Matrix;
+  raw: Matrix;
+  contributions: ContributionMatrix;
+  maxValue: number;
+}

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -74,6 +74,39 @@ describe('cli', () => {
     rmSync(dir, { recursive: true, force: true });
   }, 20000);
 
+  it('does not create images for suggestions without --image', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'ci-'));
+    const cronFile = path.join(dir, 'jobs.json');
+    writeFileSync(
+      cronFile,
+      JSON.stringify(
+        [
+          {
+            name: 'job',
+            schedule: '*/5 * * * *',
+          },
+        ],
+        null,
+        2,
+      ),
+    );
+    const result = spawnSync('node', [
+      '-r',
+      'ts-node/register',
+      cli,
+      cronFile,
+      '--suggest',
+    ]);
+    expect(result.status).toBe(0);
+    const before = path.join(dir, 'jobs.before.suggested.offset.jpg');
+    const after = path.join(dir, 'jobs.after.suggested.offset.jpg');
+    expect(existsSync(before)).toBe(false);
+    expect(existsSync(after)).toBe(false);
+    const suggestion = path.join(dir, 'jobs.suggested.json');
+    expect(existsSync(suggestion)).toBe(true);
+    rmSync(dir, { recursive: true, force: true });
+  }, 20000);
+
   it('orders suggested before reflect suffix', () => {
     const dir = mkdtempSync(path.join(tmpdir(), 'ci-'));
     const base = path.join(dir, 'heat.jpg');

--- a/test/heatmap.test.ts
+++ b/test/heatmap.test.ts
@@ -28,6 +28,7 @@ describe('heatmap', () => {
     const heatmap = buildHeatmapData(jobs);
     expect(heatmap.raw[0][0]).toBe(2);
     expect(heatmap.maxValue).toBe(2);
+    expect(heatmap.minValue).toBe(2);
     expect(heatmap.contributions[0][0]).toEqual([
       { name: 'a', status: 'starting' },
       { name: 'b', status: 'starting' },
@@ -49,7 +50,7 @@ describe('heatmap', () => {
   it('renders ascii with axis labels', () => {
     const ascii = renderAscii([Array(60).fill(0)]);
     const lines = ascii.split('\n');
-    expect(lines).toHaveLength(3);
+    expect(lines).toHaveLength(5);
     const expectedHeader =
       '    ' +
       Array.from({ length: 60 }, (_, m) =>
@@ -60,6 +61,10 @@ describe('heatmap', () => {
     expect(lines[2]).toBe(expectedHeader);
     expect(lines[1].startsWith('00 |')).toBe(true);
     expect(lines[1].endsWith('| 00')).toBe(true);
+    expect(lines[3]).toBe('');
+    expect(lines[4]).toBe(
+      'Density summary: Highest density: 0 runs. Lowest density: 0 runs.',
+    );
   });
   it('supports colors', () => {
     const row = Array(20).fill(0);
@@ -74,6 +79,16 @@ describe('heatmap', () => {
     const lines = ascii.split('\n');
     expect(lines[1].length).toBe(4 + 60 * 2 + 4);
     expect(lines[1].slice(4, -4)).toBe(' '.repeat(60 * 2));
+  });
+
+  it('renders ascii density summary from provided stats', () => {
+    const ascii = renderAscii([Array(60).fill(0)], false, {
+      maxValue: 12,
+      minValue: 3,
+    });
+    expect(ascii).toContain(
+      'Density summary: Highest density: 12 runs. Lowest density: 3 runs.',
+    );
   });
   it('renders jpeg image', () => {
     const matrix = [
@@ -224,6 +239,7 @@ describe('heatmap', () => {
     const heatmap = buildHeatmapData(jobs, true);
     const html = renderInteractiveHtml(heatmap);
     expect(html).toContain('https://www.npmjs.com/package/cron-ironer');
+    expect(html).toContain('https://github.com/brendtumi/cron-ironer');
     expect(html).toContain('data-starting="2"');
     expect(html).toContain('data-continuing="1"');
     const contributionMatches = [
@@ -243,7 +259,13 @@ describe('heatmap', () => {
       ]),
     );
     expect(html).toContain(
-      'Hover over a minute to inspect starting and continuing job contributions',
+      'Hover over a minute to inspect starting and continuing job contributions. Highest density: 2 runs. Lowest density: 1 run.',
+    );
+    expect(html).toContain(
+      'View cron-ironer on <a class="meta-link" href="https://www.npmjs.com/package/cron-ironer"',
+    );
+    expect(html).toContain(
+      '>Npm</a> or <a class="meta-link" href="https://github.com/brendtumi/cron-ironer"',
     );
   });
 

--- a/test/heatmap.test.ts
+++ b/test/heatmap.test.ts
@@ -239,5 +239,7 @@ describe('heatmap', () => {
     expect(html).toContain('data-hour="00"');
     expect(html).toContain('Hover over a minute');
     expect(html).toContain('data-jobs=');
+    expect(html).toContain('tabindex="0"');
+    expect(html).toContain('aria-label="00:00 has 1 run. Jobs: jobA."');
   });
 });


### PR DESCRIPTION
## Description

### Added

- SVG and PNG export options for cron heatmaps via the `--image-format` flag.
- Interactive HTML heatmap generation with per-minute job contribution tooltips.

### Changed

- CLI runs print the absolute paths of every generated artifact (heatmaps, HTML, suggestions) for easier discovery in automation logs.
- The interactive HTML and ASCII heatmaps now summarize both the highest and lowest cron densities, and the HTML footer links to the npm and GitHub project pages.

### Fixed

- Prevented the CLI from generating before/after heatmap images during suggestion runs unless `--image` is explicitly set.

## Checklist

- [x] I’ve run linting and formatting on my code.
- [x] I’ve added tests to confirm my change works.
- [x] I’ve run all the tests and everything passes.
- [x] I’ve documented the changes I’ve made in the documentation.
