### PR TITLE
Adjust invalid cron suggestion CLI test ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## [1.2.1] - 2025-10-05
+
 ### Changed
 
 - Sanitised suggestion outputs to omit estimation/keepTime fields and include `oldSchedule` metadata when cron timings shift.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Sanitised suggestion outputs to omit estimation/keepTime fields and include `oldSchedule` metadata when cron timings shift.
+
 ## [1.2.0] - 2025-10-04
 
 ### Added

--- a/src/parsers/serializeCrontab.ts
+++ b/src/parsers/serializeCrontab.ts
@@ -1,9 +1,12 @@
-import { Job } from '../types';
+import { SuggestedJob } from '../types';
 
-export default function serializeCrontab(jobs: Job[]): string {
+export default function serializeCrontab(jobs: SuggestedJob[]): string {
   return jobs
     .map((job) => {
-      const comment = job.description ? ` # ${job.description}` : '';
+      const details: string[] = [];
+      if (job.description) details.push(job.description);
+      if (job.oldSchedule) details.push(`old schedule: ${job.oldSchedule}`);
+      const comment = details.length > 0 ? ` # ${details.join(' | ')}` : '';
       return `${job.schedule} ${job.name}${comment}`;
     })
     .join('\n');

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,13 @@ export interface Job {
   keepTime?: boolean;
 }
 
+export interface SuggestedJob {
+  name: string;
+  schedule: string;
+  description?: string;
+  oldSchedule?: string;
+}
+
 export type Matrix = number[][]; // 24 x 60
 
 export interface HeatmapContribution {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,8 +1,15 @@
 import { describe, it, expect } from 'vitest';
-import { mkdtempSync, existsSync, rmSync, writeFileSync } from 'fs';
+import {
+  mkdtempSync,
+  existsSync,
+  rmSync,
+  writeFileSync,
+  readFileSync,
+} from 'fs';
 import { tmpdir } from 'os';
 import path from 'path';
 import { spawnSync } from 'child_process';
+import type { SuggestedJob } from '../src';
 
 const cli = path.join(__dirname, '..', 'src', 'cli.ts');
 describe('cli', () => {
@@ -146,6 +153,121 @@ describe('cli', () => {
     );
     expect(existsSync(expectedBefore)).toBe(true);
     expect(existsSync(expectedAfter)).toBe(true);
+    rmSync(dir, { recursive: true, force: true });
+  }, 20000);
+
+  it('omits estimation metadata and records old schedules in suggestions', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'ci-'));
+    const cronFile = path.join(dir, 'jobs.json');
+    writeFileSync(
+      cronFile,
+      JSON.stringify(
+        [
+          {
+            name: 'fixed-anchor',
+            schedule: '0/10 * * * *',
+            estimation: 120,
+            keepTime: true,
+          },
+          {
+            name: 'movable',
+            schedule: '*/10 * * * *',
+            estimation: 60,
+          },
+        ],
+        null,
+        2,
+      ),
+    );
+    const result = spawnSync('node', [
+      '-r',
+      'ts-node/register',
+      cli,
+      cronFile,
+      '--suggest',
+      '--optimizer',
+      'greedy',
+    ]);
+    expect(result.status).toBe(0);
+
+    const suggestionPath = path.join(dir, 'jobs.suggested.json');
+    const suggestionRaw = readFileSync(suggestionPath, 'utf8');
+    const output = JSON.parse(suggestionRaw) as SuggestedJob[];
+    expect(Array.isArray(output)).toBe(true);
+    const anchor = output.find((job) => job.name === 'fixed-anchor');
+    const movable = output.find((job) => job.name === 'movable');
+    expect(anchor).toBeDefined();
+    expect(movable).toBeDefined();
+    const hasProp = (job: SuggestedJob | undefined, key: string) =>
+      Boolean(job && Object.prototype.hasOwnProperty.call(job, key));
+    expect(anchor?.oldSchedule).toBeUndefined();
+    expect(hasProp(anchor, 'keepTime')).toBe(false);
+    expect(hasProp(anchor, 'estimation')).toBe(false);
+    expect(hasProp(movable, 'keepTime')).toBe(false);
+    expect(hasProp(movable, 'estimation')).toBe(false);
+    expect(movable?.oldSchedule).toBe('*/10 * * * *');
+    expect(movable?.schedule).not.toBe(movable?.oldSchedule);
+
+    rmSync(dir, { recursive: true, force: true });
+  }, 20000);
+
+  it('preserves invalid schedules without adding metadata in suggestions', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'ci-'));
+    const cronFile = path.join(dir, 'jobs.json');
+    writeFileSync(
+      cronFile,
+      JSON.stringify(
+        [
+          {
+            name: 'early-bird',
+            schedule: '0 0 * * *',
+          },
+          {
+            name: 'valid-job-a',
+            schedule: '*/5 * * * *',
+          },
+          {
+            name: 'broken-job',
+            schedule: 'not-a-valid-cron',
+            estimation: 45,
+          },
+          {
+            name: 'valid-job-b',
+            schedule: '15 * * * *',
+          },
+          {
+            name: 'valid-job-c',
+            schedule: '30 5 * * MON',
+          },
+        ],
+        null,
+        2,
+      ),
+    );
+
+    const result = spawnSync('node', [
+      '-r',
+      'ts-node/register',
+      cli,
+      cronFile,
+      '--suggest',
+    ]);
+
+    expect(result.status).toBe(0);
+
+    const suggestionPath = path.join(dir, 'jobs.suggested.json');
+    const suggestionRaw = readFileSync(suggestionPath, 'utf8');
+    const output = JSON.parse(suggestionRaw) as SuggestedJob[];
+    expect(output).toHaveLength(5);
+    expect(output[2]?.name).toBe('broken-job');
+    const broken = output[2];
+    const hasProp = (job: SuggestedJob | undefined, key: string) =>
+      Boolean(job && Object.prototype.hasOwnProperty.call(job, key));
+    expect(broken?.schedule).toBe('not-a-valid-cron');
+    expect(broken?.oldSchedule).toBeUndefined();
+    expect(hasProp(broken, 'estimation')).toBe(false);
+    expect(hasProp(broken, 'keepTime')).toBe(false);
+
     rmSync(dir, { recursive: true, force: true });
   }, 20000);
 });

--- a/test/resource/test-2.suggested.json
+++ b/test/resource/test-2.suggested.json
@@ -1,60 +1,50 @@
 [
   {
     "name": "job_bd7892a0",
-    "description": "word228 word442 word423 word648 word268 word536",
     "schedule": "40 0 1 * *",
-    "estimation": 8442
+    "description": "word228 word442 word423 word648 word268 word536"
   },
   {
     "name": "job_3c13a828",
-    "schedule": "0 */2 * * *",
-    "estimation": 304
+    "schedule": "0 */2 * * *"
   },
   {
     "name": "job_d70d9e02",
-    "description": "word248 word878 word824 word371 word482 word816 word354 word807 word697 word615 word575 word862 word738",
     "schedule": "10,40 * * * *",
-    "estimation": 1799
+    "description": "word248 word878 word824 word371 word482 word816 word354 word807 word697 word615 word575 word862 word738"
   },
   {
     "name": "job_3f85db48",
-    "description": "word850 word673 word187 word860 word685 word902 word849 word688 word554 word904",
     "schedule": "5 * 24-31 * *",
-    "estimation": 769
+    "description": "word850 word673 word187 word860 word685 word902 word849 word688 word554 word904"
   },
   {
     "name": "job_2044d089",
-    "description": "word944 word154 word971 word556 word366 word491 word902",
-    "schedule": "0 2 * * *",
-    "estimation": 6908
+    "schedule": "0 13 * * *",
+    "description": "word944 word154 word971 word556 word366 word491 word902"
   },
   {
     "name": "job_b6776bf0",
-    "schedule": "0 0 * * 0",
-    "estimation": 1697
+    "schedule": "0 0 * * 0"
   },
   {
     "name": "job_47b0958c",
-    "description": "word852 word195 word432 word815 word608 word134 word101 word933 word750",
     "schedule": "0 * * * *",
-    "estimation": 1509
+    "description": "word852 word195 word432 word815 word608 word134 word101 word933 word750"
   },
   {
     "name": "job_625ccdff",
-    "description": "word935 word832 word772 word599 word638 word488 word753 word637 word288 word473 word286 word316 word448 word613 word383 word180 word712 word906",
-    "schedule": "0 4 * * *",
-    "estimation": 4221
+    "schedule": "0 2 * * *",
+    "description": "word935 word832 word772 word599 word638 word488 word753 word637 word288 word473 word286 word316 word448 word613 word383 word180 word712 word906"
   },
   {
     "name": "job_d91e91ec",
-    "description": "word543 word613 word866 word676 word802 word389",
     "schedule": "0 1 1 * *",
-    "estimation": 5347
+    "description": "word543 word613 word866 word676 word802 word389"
   },
   {
     "name": "job_6f9fba8f",
-    "description": "word204 word546 word568 word306 word977 word929 word426 word812 word891 word630 word612 word143",
-    "schedule": "0 1/2 * * *",
-    "estimation": 1365
+    "schedule": "0 */2 * * *",
+    "description": "word204 word546 word568 word306 word977 word929 word426 word812 word891 word630 word612 word143"
   }
 ]

--- a/test/resource/test-3.suggested.json
+++ b/test/resource/test-3.suggested.json
@@ -1,61 +1,55 @@
 [
   {
     "name": "job_cbbd7e5b",
-    "description": "word476 word544 word760 word981 word206 word914 word550",
     "schedule": "0 1 2 * *",
-    "estimation": 4634
+    "description": "word476 word544 word760 word981 word206 word914 word550"
   },
   {
     "name": "job_d994543e",
-    "description": "word141 word803 word675 word878 word362",
     "schedule": "24/30 * * * *",
-    "estimation": 82
+    "description": "word141 word803 word675 word878 word362",
+    "oldSchedule": "*/30 * * * *"
   },
   {
     "name": "job_f9465436",
     "schedule": "41/50 * * * *",
-    "estimation": 35
+    "oldSchedule": "*/50 * * * *"
   },
   {
     "name": "job_1fe3f871",
-    "description": "word417 word334 word613 word247 word514 word391 word327",
     "schedule": "2/10 * * * *",
-    "estimation": 60
+    "description": "word417 word334 word613 word247 word514 word391 word327",
+    "oldSchedule": "*/10 * * * *"
   },
   {
     "name": "job_9a9aa267",
-    "description": "word397 word850 word100 word384 word825 word335 word496 word967 word122",
     "schedule": "0 9 * * *",
-    "estimation": 1045
+    "description": "word397 word850 word100 word384 word825 word335 word496 word967 word122"
   },
   {
     "name": "job_bd7892a0",
-    "description": "word228 word442 word423 word648 word268 word536",
     "schedule": "40 0 1 * *",
-    "estimation": 8442
+    "description": "word228 word442 word423 word648 word268 word536"
   },
   {
     "name": "job_72193c23",
-    "description": "word344 word160 word332 word666 word802",
     "schedule": "0 */24 * * *",
-    "estimation": 1413
+    "description": "word344 word160 word332 word666 word802"
   },
   {
     "name": "job_ed2b3b3d",
-    "description": "word526 word100 word562 word261 word106 word916 word257 word330",
     "schedule": "5 */2 * * *",
-    "estimation": 2152
+    "description": "word526 word100 word562 word261 word106 word916 word257 word330"
   },
   {
     "name": "job_34ec3456",
-    "description": "word818 word281 word690 word618 word129 word591 word314 word263 word288 word306",
     "schedule": "13/15 * * * *",
-    "estimation": 44
+    "description": "word818 word281 word690 word618 word129 word591 word314 word263 word288 word306",
+    "oldSchedule": "*/15 * * * *"
   },
   {
     "name": "job_2b153982",
-    "description": "word170 word878 word555 word419 word336 word552 word271",
     "schedule": "0 22 * * 1",
-    "estimation": 5795
+    "description": "word170 word878 word555 word419 word336 word552 word271"
   }
 ]

--- a/test/resource/test-4.suggested.json
+++ b/test/resource/test-4.suggested.json
@@ -1,61 +1,54 @@
 [
   {
     "name": "job_36aeffb9",
-    "description": "word518 word838 word616 word940 word367 word362 word581 word489",
     "schedule": "55 */12 * * *",
-    "estimation": 1483
+    "description": "word518 word838 word616 word940 word367 word362 word581 word489"
   },
   {
     "name": "job_43c237f1",
-    "description": "word553 word282 word326 word326 word445 word701 word621 word413 word808",
     "schedule": "05 1,13 * * *",
-    "estimation": 1129
+    "description": "word553 word282 word326 word326 word445 word701 word621 word413 word808"
   },
   {
     "name": "job_233233e5",
-    "description": "word362 word906 word209 word483 word401 word504 word857 word327 word464 word829 word764 word624 word428 word357",
     "schedule": "40 */12 * * *",
-    "estimation": 360
+    "description": "word362 word906 word209 word483 word401 word504 word857 word327 word464 word829 word764 word624 word428 word357"
   },
   {
     "name": "job_87cee9c8",
-    "description": "word410 word989 word722 word257 word514 word965 word301",
     "schedule": "0 */4 * * *",
-    "estimation": 1012
+    "description": "word410 word989 word722 word257 word514 word965 word301"
   },
   {
     "name": "job_cd484791",
-    "description": "word899 word756 word849 word973",
     "schedule": "0 1 * * *",
-    "estimation": 4823
+    "description": "word899 word756 word849 word973"
   },
   {
     "name": "job_0d0ebb53",
-    "description": "word560 word213 word181 word519 word810 word921 word122 word181 word616 word227 word259 word785 word207",
     "schedule": "45 * * * *",
-    "estimation": 480
+    "description": "word560 word213 word181 word519 word810 word921 word122 word181 word616 word227 word259 word785 word207"
   },
   {
     "name": "job_4fdfc8eb",
-    "description": "word610 word350 word735 word702 word620 word189 word934 word776 word590",
     "schedule": "0 1 19,20,21 3 *",
-    "estimation": 6810
+    "description": "word610 word350 word735 word702 word620 word189 word934 word776 word590"
   },
   {
     "name": "job_27e6cd33",
     "schedule": "23/30 * * * *",
-    "estimation": 89
+    "oldSchedule": "*/30 * * * *"
   },
   {
     "name": "job_b77acd9e",
-    "description": "word540 word673 word100 word460 word686 word532",
     "schedule": "10/15 * * * *",
-    "estimation": 80
+    "description": "word540 word673 word100 word460 word686 word532",
+    "oldSchedule": "*/15 * * * *"
   },
   {
     "name": "job_c9096662",
-    "description": "word647 word862 word800 word228",
     "schedule": "12/15 * * * *",
-    "estimation": 69
+    "description": "word647 word862 word800 word228",
+    "oldSchedule": "*/15 * * * *"
   }
 ]

--- a/test/resource/test-5.suggested.json
+++ b/test/resource/test-5.suggested.json
@@ -1,61 +1,53 @@
 [
   {
     "name": "job_ff895cbb",
-    "description": "word819 word893 word559 word557 word765",
     "schedule": "0 0 * * *",
-    "estimation": 746
+    "description": "word819 word893 word559 word557 word765"
   },
   {
     "name": "job_cde1deba",
-    "description": "word849 word576 word840 word355 word807",
     "schedule": "3/5 * * * *",
-    "estimation": 51
+    "description": "word849 word576 word840 word355 word807",
+    "oldSchedule": "*/5 * * * *"
   },
   {
     "name": "job_c8260096",
-    "description": "word331 word903 word513 word196 word518 word724",
     "schedule": "0 * * * *",
-    "estimation": 1065
+    "description": "word331 word903 word513 word196 word518 word724"
   },
   {
     "name": "job_495e7bbe",
-    "description": "word599 word645 word823 word468 word899 word164 word173 word636 word864 word642 word546 word635 word995 word901",
     "schedule": "0 * * * *",
-    "estimation": 1296
+    "description": "word599 word645 word823 word468 word899 word164 word173 word636 word864 word642 word546 word635 word995 word901"
   },
   {
     "name": "job_3c13a828",
-    "schedule": "0 */2 * * *",
-    "estimation": 304
+    "schedule": "0 */2 * * *"
   },
   {
     "name": "job_92e95e94",
-    "description": "word123 word900 word874 word445 word412 word720 word504 word225 word135 word522",
     "schedule": "4/5 * * * *",
-    "estimation": 53
+    "description": "word123 word900 word874 word445 word412 word720 word504 word225 word135 word522",
+    "oldSchedule": "*/5 * * * *"
   },
   {
     "name": "job_242ccb7e",
-    "description": "word506 word648 word646 word132 word661 word328 word782 word437",
     "schedule": "50 */12 * * *",
-    "estimation": 870
+    "description": "word506 word648 word646 word132 word661 word328 word782 word437"
   },
   {
     "name": "job_896a02be",
-    "description": "word367 word596 word484 word286 word865 word951 word631 word765",
     "schedule": "0 * * * *",
-    "estimation": 406
+    "description": "word367 word596 word484 word286 word865 word951 word631 word765"
   },
   {
     "name": "job_2ebc6e8f",
-    "description": "word806 word314 word842 word492 word126 word561 word639 word918 word590",
     "schedule": "0 0 26 * *",
-    "estimation": 9645
+    "description": "word806 word314 word842 word492 word126 word561 word639 word918 word590"
   },
   {
     "name": "job_aedb50e9",
-    "description": "word870 word824 word935 word586 word236",
     "schedule": "0 0 * * *",
-    "estimation": 610
+    "description": "word870 word824 word935 word586 word236"
   }
 ]

--- a/test/resource/test-6.suggested.yaml
+++ b/test/resource/test-6.suggested.yaml
@@ -1,41 +1,33 @@
 - name: job_ff895cbb
-  description: word819 word893 word559 word557 word765
   schedule: 0 0 * * *
-  estimation: 746
+  description: word819 word893 word559 word557 word765
 - name: job_cde1deba
-  description: word849 word576 word840 word355 word807
   schedule: 3/5 * * * *
-  estimation: 51
+  description: word849 word576 word840 word355 word807
+  oldSchedule: "*/5 * * * *"
 - name: job_c8260096
-  description: word331 word903 word513 word196 word518 word724
   schedule: 0 * * * *
-  estimation: 1065
+  description: word331 word903 word513 word196 word518 word724
 - name: job_495e7bbe
+  schedule: 0 * * * *
   description: word599 word645 word823 word468 word899 word164 word173 word636
     word864 word642 word546 word635 word995 word901
-  schedule: 0 * * * *
-  estimation: 1296
 - name: job_3c13a828
   schedule: 0 */2 * * *
-  estimation: 304
 - name: job_92e95e94
+  schedule: 4/5 * * * *
   description: word123 word900 word874 word445 word412 word720 word504 word225
     word135 word522
-  schedule: 4/5 * * * *
-  estimation: 53
+  oldSchedule: "*/5 * * * *"
 - name: job_242ccb7e
-  description: word506 word648 word646 word132 word661 word328 word782 word437
   schedule: 50 */12 * * *
-  estimation: 870
+  description: word506 word648 word646 word132 word661 word328 word782 word437
 - name: job_896a02be
-  description: word367 word596 word484 word286 word865 word951 word631 word765
   schedule: 0 * * * *
-  estimation: 406
+  description: word367 word596 word484 word286 word865 word951 word631 word765
 - name: job_2ebc6e8f
-  description: word806 word314 word842 word492 word126 word561 word639 word918 word590
   schedule: 0 0 26 * *
-  estimation: 9645
+  description: word806 word314 word842 word492 word126 word561 word639 word918 word590
 - name: job_aedb50e9
-  description: word870 word824 word935 word586 word236
   schedule: 0 0 * * *
-  estimation: 610
+  description: word870 word824 word935 word586 word236

--- a/test/serializeCrontab.test.ts
+++ b/test/serializeCrontab.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { serializeCrontab, Job } from '../src';
+import { serializeCrontab, Job, SuggestedJob } from '../src';
 
 describe('serializeCrontab', () => {
   it('serializes jobs with and without descriptions correctly', () => {
@@ -19,5 +19,18 @@ describe('serializeCrontab', () => {
 
   it('returns empty string for empty job list', () => {
     expect(serializeCrontab([])).toBe('');
+  });
+
+  it('appends old schedule details when provided', () => {
+    const jobs: SuggestedJob[] = [
+      {
+        name: 'rotate-logs',
+        schedule: '5 0 * * *',
+        oldSchedule: '0 0 * * *',
+      },
+    ];
+    expect(serializeCrontab(jobs)).toBe(
+      '5 0 * * * rotate-logs # old schedule: 0 0 * * *',
+    );
   });
 });


### PR DESCRIPTION
## Description

Sanitised suggestion outputs to omit estimation/keepTime fields and include `oldSchedule` metadata when cron timings shift.

## Checklist

- [x] I’ve run linting and formatting on my code.
- [x] I’ve added tests to confirm my change works.
- [x] I’ve run all the tests and everything passes.
- [ ] I’ve documented the changes I’ve made in the documentation.
